### PR TITLE
rewrite reminder command to also work as slash command

### DIFF
--- a/src/main/kotlin/de/runebot/Taskmaster.kt
+++ b/src/main/kotlin/de/runebot/Taskmaster.kt
@@ -2,15 +2,20 @@ package de.runebot
 
 import de.runebot.database.DB
 import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.MessageChannelBehavior
+import dev.kord.core.behavior.channel.createMessage
 import dev.kord.core.entity.ReactionEmoji
 import dev.kord.x.emoji.Emojis
 import kotlinx.coroutines.delay
+import kotlinx.datetime.Clock
+import java.time.format.DateTimeFormatter
 
 object Taskmaster
 {
     private var running = false
 
+    private var oldTimers = DB.getAllOldTimers()
     private var timers = DB.getAllTimers()
 
     suspend fun run()
@@ -19,14 +24,15 @@ object Taskmaster
         while (running)
         {
             checkTimers()
+            checkOldTimers()
             delay(1000)
         }
     }
 
-    private suspend fun checkTimers() // TODO: support new subscription system: make new DB and ignore old one
+    private suspend fun checkOldTimers() // TODO: support new subscription system: make new DB and ignore old one
     {
         RuneBot.kord?.let { kord ->
-            timers.filter {
+            oldTimers.filter {
                 it.targetTime <= System.currentTimeMillis()
             }.forEach { (_, message, channelId, messageId) ->
                 val channel = MessageChannelBehavior(Snowflake(channelId), kord)
@@ -41,14 +47,41 @@ object Taskmaster
                     builtMessage.append(it.mention).append(" ")
                 }
                 Util.sendMessage(channel, builtMessage.toString())
-                DB.removeTimer(channelId, messageId)
+                DB.removeOldTimer(channelId, messageId)
                 updateTimers()
             }
         }
     }
 
+    private suspend fun checkTimers()
+    {
+        RuneBot.kord?.let { kord ->
+            val now = Clock.System.now()
+
+            timers
+                .sortedBy { it.targetTime } // sort for performance improvement
+                .forEach { (creatorId, targetTime, message, subscriberIds) ->
+                    if (targetTime > now)
+                    {
+                        return // possible, because list is sorted
+                    }
+
+                    subscriberIds.forEach { userId ->
+                        UserBehavior(Snowflake(userId), kord).getDmChannelOrNull()?.let { dmChannel ->
+                            dmChannel.createMessage {
+                                content = "**Reminder for ${DateTimeFormatter.RFC_1123_DATE_TIME}**" +
+                                        "\n$message"
+                            }
+                        }
+                    }
+
+                    // TODO: remove from db
+                }
+        }
+    }
+
     fun updateTimers()
     {
-        timers = DB.getAllTimers()
+        oldTimers = DB.getAllOldTimers()
     }
 }

--- a/src/main/kotlin/de/runebot/Taskmaster.kt
+++ b/src/main/kotlin/de/runebot/Taskmaster.kt
@@ -23,7 +23,7 @@ object Taskmaster
         }
     }
 
-    private suspend fun checkTimers()
+    private suspend fun checkTimers() // TODO: support new subscription system: make new DB and ignore old one
     {
         RuneBot.kord?.let { kord ->
             timers.filter {

--- a/src/main/kotlin/de/runebot/commands/ReminderCommand.kt
+++ b/src/main/kotlin/de/runebot/commands/ReminderCommand.kt
@@ -3,40 +3,68 @@ package de.runebot.commands
 import de.runebot.Taskmaster
 import de.runebot.Util
 import de.runebot.database.DB
-import de.runebot.database.DBResponse.SUCCESS
+import dev.kord.common.toMessageFormat
 import dev.kord.core.Kord
 import dev.kord.core.behavior.interaction.respondEphemeral
 import dev.kord.core.behavior.interaction.respondPublic
-import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.event.interaction.ChatInputCommandInteractionCreateEvent
 import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.rest.builder.interaction.*
-import dev.kord.x.emoji.Emojis
+import kotlinx.datetime.Clock
 import kotlin.time.Duration
 
 object ReminderCommand : RuneTextCommand, RuneSlashCommand
 {
     private const val NO_MESSAGE_SET = "You didn't set a message, but your timer expired!"
 
+    private val subscribeSubCommand = RuneTextCommand.Subcommand(
+        RuneTextCommand.CommandDescription(listOf("subscribe"), "subscribe <id>" to "subscribe to an active reminder"),
+        { event, args, _ ->
+            val id = args[0].toIntOrNull()
+            val userId = event.message.author?.id?.value
+
+            if (id != null && userId != null)
+            {
+                val timer = DB.subscribeToTimer(id, userId)
+                if (timer != null)
+                {
+                    Util.sendMessage(event, "Successfully subscribed to $timer.")
+                }
+            }
+
+
+
+
+            Util.sendMessage(event, "${args[0]} is not a valid id. Use `>reminder list <someUser>` to find the right id.") // TODO: create subcommand
+        }, emptyList()
+    )
+
     private val reminder = RuneTextCommand.Subcommand(
         RuneTextCommand.CommandDescription(names, Pair("reminder <time> <message>", "After specified time, posts the given message and mentions the author and reactors.")),
         { event, args, _ ->
             // Extract time
             val duration = convertInputStringToDuration(args[0])
+            val targetTime = Clock.System.now() + duration
 
             // DB Operation
-            val userMessage = if (args.size > 1) args.subList(1, args.size).joinToString(" ") else NO_MESSAGE_SET
+            val message = if (args.size > 1) args.subList(1, args.size).joinToString(" ") else NO_MESSAGE_SET
 
-            DB.addTimer(duration, userMessage, event.message.channelId.value.toLong(), event.message.id.value.toLong())
+            val creatorId = event.message.author?.id?.value
 
-            // Taskmaster foo
-            Taskmaster.updateTimers()
-
-            // Response message foo
-            event.message.addReaction(ReactionEmoji.Unicode(Emojis.alarmClock.unicode))
-            Util.sendMessage(event, "Timer was set for ${duration}. React, if you want to get pinged too as soon as the timer runs out!")
+            if (creatorId != null)
+            {
+                DB.addTimer(creatorId, targetTime, message)?.let { timer ->
+                    Taskmaster.updateTimers()
+                    Util.sendMessage(
+                        event,
+                        "Timer was set for ${targetTime.toMessageFormat()}. Subscribe to this reminder with `>reminder subscribe ${timer.id}`."
+                    )
+                    return@Subcommand
+                }
+            }
+            Util.sendMessage(event, "error creating reminder")
         },
-        emptyList()
+        listOf(subscribeSubCommand)
     )
 
     override val names: List<String>
@@ -45,7 +73,6 @@ object ReminderCommand : RuneTextCommand, RuneSlashCommand
         get() = "reminds users for the specified reasons"
     override val longHelpText: String
         get() = reminder.toTree().toString()
-    private val regex = Regex("\\d+[smhd]")
 
     override fun prepare(kord: Kord)
     {
@@ -75,7 +102,7 @@ object ReminderCommand : RuneTextCommand, RuneSlashCommand
     {
         with(builder)
         {
-            subCommand("create", "create a new reminder")
+            subCommand("new", "create a new reminder")
             {
                 string("duration", "duration after now until the reminder will trigger")
                 {
@@ -95,11 +122,7 @@ object ReminderCommand : RuneTextCommand, RuneSlashCommand
             }
             subCommand("subscribe", "subscribe to an active reminder")
             {
-                user("target", "who this reminder belongs to")
-                {
-                    required = true
-                }
-                integer("index", "which one according to /reminder list")
+                integer("id", "id according to /reminder list")
                 {
                     required = true
                 }
@@ -120,31 +143,18 @@ object ReminderCommand : RuneTextCommand, RuneSlashCommand
                     val durationString = interaction.command.strings["duration"]!!
                     val duration = convertInputStringToDuration(durationString)
                     val message = interaction.command.strings["message"] ?: NO_MESSAGE_SET
-                    val targetTime = System.currentTimeMillis() + duration.inWholeMilliseconds
-                    val channelId = interaction.channelId.value.toLong()
+                    val targetTime = Clock.System.now() + duration
+                    val creatorId = interaction.user.id.value
 
-                    val dbResponse = DB.addTimer(targetTime, message, channelId, -1) // -1 should not be an occurring snowflake, as we ignore that part of the DB.
-
-                    when (dbResponse)
-                    {
-                        SUCCESS ->
-                        {
-                            Taskmaster.updateTimers()
-                            val timerIndex = DB.getAllOldTimers().mapIndexed { index: Int, oldTimerEntry: DB.OldTimerEntry -> index to oldTimerEntry }
-                                .find { DB.OldTimerEntry(targetTime, message, channelId, -1) == it.second }?.first
-
-                            interaction.respondPublic {
-                                content = "Timer was set for ${duration}." + if (timerIndex != null) " Subscribe to this reminder with `/reminder subscribe $timerIndex`." else ""
-                            }
+                    DB.addTimer(creatorId, targetTime, message)?.let { timer ->
+                        Taskmaster.updateTimers()
+                        interaction.respondPublic {
+                            content = "Timer was set for ${targetTime.toMessageFormat()}. Subscribe to this reminder with `/reminder subscribe ${timer.id}`."
                         }
-
-                        else ->
-                        {
-                            interaction.respondEphemeral { content = "error creating reminder" }
-                        }
+                        return
                     }
 
-
+                    interaction.respondEphemeral { content = "error creating reminder" }
                 }
 
                 "list" ->

--- a/src/main/kotlin/de/runebot/commands/ReminderCommand.kt
+++ b/src/main/kotlin/de/runebot/commands/ReminderCommand.kt
@@ -10,9 +10,7 @@ import dev.kord.core.behavior.interaction.respondPublic
 import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.event.interaction.ChatInputCommandInteractionCreateEvent
 import dev.kord.core.event.message.MessageCreateEvent
-import dev.kord.rest.builder.interaction.GlobalChatInputCreateBuilder
-import dev.kord.rest.builder.interaction.string
-import dev.kord.rest.builder.interaction.subCommand
+import dev.kord.rest.builder.interaction.*
 import dev.kord.x.emoji.Emojis
 import kotlin.time.Duration
 
@@ -88,13 +86,23 @@ object ReminderCommand : RuneTextCommand, RuneSlashCommand
                     required = false
                 }
             }
-            subCommand("list", "list currently active reminders")
+            subCommand("list", "list a users currently active reminders")
             {
-
+                user("target", "what user's reminders to list")
+                {
+                    required = false
+                }
             }
             subCommand("subscribe", "subscribe to an active reminder")
             {
-
+                user("target", "who this reminder belongs to")
+                {
+                    required = true
+                }
+                integer("index", "which one according to /reminder list")
+                {
+                    required = true
+                }
             }
         }
     }
@@ -122,8 +130,8 @@ object ReminderCommand : RuneTextCommand, RuneSlashCommand
                         SUCCESS ->
                         {
                             Taskmaster.updateTimers()
-                            val timerIndex = DB.getAllTimers().mapIndexed { index: Int, timerEntry: DB.TimerEntry -> index to timerEntry }
-                                .find { DB.TimerEntry(targetTime, message, channelId, -1) == it.second }?.first
+                            val timerIndex = DB.getAllOldTimers().mapIndexed { index: Int, oldTimerEntry: DB.OldTimerEntry -> index to oldTimerEntry }
+                                .find { DB.OldTimerEntry(targetTime, message, channelId, -1) == it.second }?.first
 
                             interaction.respondPublic {
                                 content = "Timer was set for ${duration}." + if (timerIndex != null) " Subscribe to this reminder with `/reminder subscribe $timerIndex`." else ""

--- a/src/main/kotlin/de/runebot/database/DB.kt
+++ b/src/main/kotlin/de/runebot/database/DB.kt
@@ -259,6 +259,8 @@ object DB
     fun subscribeToTimer(id: Int, userId: ULong): TimerEntry?
     {
         val timer = getTimer(id) ?: return null
+        val subscribers = timer.subscriberIds.toMutableList()
+        subscribers.add(userId)
 
         try
         {
@@ -266,7 +268,7 @@ object DB
                 TimersV2.update(where = {
                     TimersV2.id eq id
                 }) {
-                    it[this.subscriberIds] = serializer.encodeToString(timer.subscriberIds.toMutableList().add(userId))
+                    it[this.subscriberIds] = serializer.encodeToString(subscribers)
                 }
             }
             return timer
@@ -363,7 +365,7 @@ object DB
     {
         override fun toString(): String
         {
-            return "$id: ${targetTime.toMessageFormat()} $message"
+            return "($id) ${targetTime.toMessageFormat()} \"$message\""
         }
 
         companion object

--- a/src/main/kotlin/de/runebot/database/WeirdFetishButOK.kt
+++ b/src/main/kotlin/de/runebot/database/WeirdFetishButOK.kt
@@ -25,12 +25,13 @@ object Timers : Table()
 
 object TimersV2 : Table()
 {
+    val id = integer("id").autoIncrement()
     val creatorId = ulong("creatorId")
     val targetTime = timestamp("targetTime")
     val message = text("message")
     val subscriberIds = text("subscriberIds") // list of uLongs as JSON
 
-    override val primaryKey = PrimaryKey(creatorId, targetTime, message)
+    override val primaryKey = PrimaryKey(id)
 }
 
 object Tags : Table()

--- a/src/main/kotlin/de/runebot/database/WeirdFetishButOK.kt
+++ b/src/main/kotlin/de/runebot/database/WeirdFetishButOK.kt
@@ -3,6 +3,7 @@ package de.runebot.database
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.javatime.date
+import org.jetbrains.exposed.sql.javatime.timestamp
 import java.time.LocalDate
 
 //region Main DB
@@ -20,6 +21,16 @@ object Timers : Table()
     val message: Column<String> = text("message")
     val channelId: Column<Long> = long("channelId")
     val messageId: Column<Long> = long("messageId")
+}
+
+object TimersV2 : Table()
+{
+    val creatorId = ulong("creatorId")
+    val targetTime = timestamp("targetTime")
+    val message = text("message")
+    val subscriberIds = text("subscriberIds") // list of uLongs as JSON
+
+    override val primaryKey = PrimaryKey(creatorId, targetTime, message)
 }
 
 object Tags : Table()


### PR DESCRIPTION
reacting with emojis no longer works, but a `subscribe` subcommand handles an alternative.
old active timers should still trigger, but will eventually be obsolete.