### PR TITLE
Fix crash and data-corruption bugs in commands

### DIFF
--- a/src/main/kotlin/de/runebot/commands/AnilistCommand.kt
+++ b/src/main/kotlin/de/runebot/commands/AnilistCommand.kt
@@ -29,10 +29,11 @@ object AnilistCommand : RuneTextCommand
             val result = serializer.decodeFromString<Root>(response.body())
             val bobTheStringBuilder = StringBuilder("Found results:\n")
             result.data.Page.media.forEach { media ->
-                media.title.english?.let { bobTheStringBuilder.append(it).append("//") }
-                media.title.native?.let { bobTheStringBuilder.append(it).append("//") }
-                media.title.romaji?.let { bobTheStringBuilder.append(it).append("//") }
-                bobTheStringBuilder.trim { it == '/' }
+                val titleBuilder = StringBuilder()
+                media.title.english?.let { titleBuilder.append(it).append("//") }
+                media.title.native?.let { titleBuilder.append(it).append("//") }
+                media.title.romaji?.let { titleBuilder.append(it).append("//") }
+                bobTheStringBuilder.append(titleBuilder.toString().trim { it == '/' })
                 bobTheStringBuilder.append(System.lineSeparator())
             }
             // Test

--- a/src/main/kotlin/de/runebot/commands/NumbersCommand.kt
+++ b/src/main/kotlin/de/runebot/commands/NumbersCommand.kt
@@ -268,8 +268,7 @@ object NumbersCommand : RuneTextCommand
         val page = CataloguePage()
 
         // Processing values
-        val combinedTitle = data.name
-        data.original_name?.let { combinedTitle.plus("${System.lineSeparator()}$it") }
+        val combinedTitle = data.original_name?.let { "${data.name}${System.lineSeparator()}$it" } ?: data.name
 
         // Applying them
         page.setTitle("$number")
@@ -430,7 +429,7 @@ object NumbersCommand : RuneTextCommand
                 name,
                 original_name ?: "",
                 parodies,
-                categories,
+                characters,
                 tags,
                 artists,
                 groups,

--- a/src/main/kotlin/de/runebot/commands/ReminderCommand.kt
+++ b/src/main/kotlin/de/runebot/commands/ReminderCommand.kt
@@ -54,6 +54,7 @@ object ReminderCommand : RuneTextCommand
         if (args.size <= 1)
         {
             Util.sendMessage(event, "Please specify a time.")
+            return
         }
         if (names.contains(args[0].substring(1))) reminder.execute(event, args.subList(1, args.size), listOf(args[0].substring(1)))
     }


### PR DESCRIPTION
- ReminderCommand: return after the missing-time-arg message instead of falling through to args[0], which crashed on >reminder with no args
- AnilistCommand: actually use the trimmed title instead of discarding the result of StringBuilder.trim{}
- NumbersCommand: apply the original_name suffix to the embed title instead of discarding the result of String.plus
- NumbersCommand: fix saveToDB passing categories instead of characters to DB.storeDoujin, which overwrote a doujin's characters with its categories